### PR TITLE
Updated nccc-group's fork of pyuv to support Python 3.11

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,6 +32,11 @@ pyuv's features:
 - Arbitrary file descriptor polling
 - Thread synchronization primitives
 
+This fork
+=========
+
+This fork includes very minor and minimal updates so ``pyuv`` 
+can be used with newer releases of Python 3, including 3.11. 
 
 CI status
 =========
@@ -73,6 +78,8 @@ pyuv can be installed via pip as follows:
     pip install pyuv
 
 
+It can also be installed from a local build, as shown in the next section for Linux.
+
 Building
 ========
 
@@ -88,6 +95,7 @@ Linux:
 ::
 
     ./build_inplace
+    pip install -e .
 
 Mac OSX:
 
@@ -107,11 +115,12 @@ Microsoft Windows (with Visual Studio):
 Running the test suite
 ======================
 
-There are several ways of running the test ruite:
+There are several ways of running the test suite:
 
 - Run the test with the current Python interpreter:
 
   From the toplevel directory, run: ``nosetests -v``
+  (Debian/Ubuntu nose can be installed with ``sudo apt install python3-nose``)
 
 - Use Tox to run the test suite in several virtualenvs with several interpreters
 

--- a/src/common.c
+++ b/src/common.c
@@ -39,7 +39,11 @@ pyuv_PyUnicode_EncodeFSDefault(PyObject *unicode)
         return PyUnicode_AsEncodedString(unicode, Py_FileSystemDefaultEncoding, "surrogateescape");
     else
 #endif
-        return PyUnicode_EncodeUTF8(PyUnicode_AS_UNICODE(unicode), PyUnicode_GET_SIZE(unicode), "surrogateescape");
+#if PY_MAJOR_VERSION * 100 + PY_MINOR_VERSION >= 311
+        return PyUnicode_AsUTF8String(unicode);
+#else	    
+	return PyUnicode_EncodeUTF8(PyUnicode_AS_UNICODE(unicode), PyUnicode_GET_SIZE(unicode), "surrogateescape");
+#endif
 }
 
 


### PR DESCRIPTION
The changes are the minimum necessary to support
https://github.com/KatharaFramework/Kathara-Labs/ tutorial https://github.com/KatharaFramework/Kathara-Labs/tree/main/tutorials/python-api/managing-filesystem There may be other aspects of the code that need improving to provide full support for Python 3.11

Tested via the managing-filesystem tutorial's `connect_tty` and by running the automated tests with nosetests3 (as per this project's README file).

PS: thank you for your fork of the original project that enabled me to create this fork and PR based on your work.